### PR TITLE
A few QOL changes for the CLI

### DIFF
--- a/tools/poststation-cli/src/main.rs
+++ b/tools/poststation-cli/src/main.rs
@@ -145,7 +145,6 @@ async fn inner_main(cli: Cli) -> anyhow::Result<()> {
             message,
             path,
         } => {
-            //HACK Don't think as_deref is the right thing here
             let serial = guess_serial(serial.as_deref(), &client).await?;
             device_proxy(client, serial, path, message).await
         }
@@ -155,7 +154,6 @@ async fn inner_main(cli: Cli) -> anyhow::Result<()> {
             path,
         } => device_publish(client, serial, path, message).await,
         Commands::Endpoints { serial } => {
-            //HACK Don't think as_deref is the right thing here
             let serial_num = guess_serial(serial.as_deref(), &client).await?;
 
             println!("{serial_num:016X}");
@@ -423,7 +421,6 @@ async fn device_cmds(client: SquadClient, device: &Device) -> anyhow::Result<()>
                 bail!("Too many matches, be more specific!");
             } else {
                 let ep = matches[0];
-                //TODO: A command that doesn't require a response? That's what I'm trying to catch here but feel like I may be missing a couple of cases
                 if ep.req_ty.ty == OwnedDataModelType::Unit {
                     device_proxy(client, serial, ep.path.clone(), "".to_string()).await?;
                     return Ok(());


### PR DESCRIPTION
This PR adds some new features and changes a couple of the cli commands.

## New Features
* Ability to set the env variable `POSTSTATION_SERIAL` so you do not need to pass a device serial for each command. The idea behind this is to make it a bit faster when prototyping or learning how to use Poststation. 
* Moved device commands and `proxy` to use `guess_serial`
* Added a new device command `smart-proxy` that lets you send shorter commands, and it takes a guess at which endpoint you meant.  It also trys to make it a bit easier to pass enum values. The end result if you have a env variable for turning on the LED in the template looks like this `poststation-cli device smart-proxy led/set On`

## Concerns
* I do think with the `guess_serial` it changes which version of the serial number is displayed in the command line and may not be expected.
* I used `as_deref` in a couple of places to go from `Option<String>` to `Option<&str>` Not sure if that's correct or best practice.
* With serial being optional in a few places I used bail to explain to the user if its not in env or passed as a command. Does not look or feel very "cli", there may be a better solution with claps framework.
* In the SmartProxy I try to guess if an endpoint doesn't take a request with () not sure if that covers all use cases

Please feel free to let me know if there's anything I should change, and I will take a look at it when I can! 