### PR TITLE
feat: add auto completion shell support  for `poststation-cli`

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -203,6 +203,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "375f9d8255adeeedd51053574fd8d4ba875ea5fa558e86617b07f09f1680c8b6"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +744,7 @@ version = "0.4.3"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete",
  "directories",
  "postcard",
  "postcard-rpc",

--- a/tools/poststation-cli/Cargo.toml
+++ b/tools/poststation-cli/Cargo.toml
@@ -11,6 +11,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow      = "1.0.89"
 clap        = { version = "4.5.19", features = ["derive"] }
+clap_complete = "4.5.44"
 directories = "5.0.1"
 rand = "0.8.5"
 serde_json  = "1.0.128"


### PR DESCRIPTION
While playing around with Poststation, I thought it'd be nice if I could use `<TAB>` so the cli utils could suggest what args or sub-commands I should use next, this little PR supports that feature.

a small note here is that to maintain the current behavior of `DeviceCommands`, I've changed a little bit in `Logs` and `LogsRange` args from _optional_ to _default value_, this is to avoid clap validation issue  that required positional arguments must come before optional ones in the command definition.
otherwise it will cause an error when building similar to the following error:
```bash
thread 'main' panicked at /home/thaodinh/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.5.20/src/builder/debug_asserts.rs:638:17:
Found non-required positional argument with a lower index than a required positional argument: "count" index Some(1)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

please let me know if you think this is unreasonable.

Also the approach when generating specific shell auto-completion is to immediately process that command first instead of waiting for network connection and handle later. Because I think this feature does not need network connection to generate.